### PR TITLE
Update maven plugins and require Maven 3.2.1

### DIFF
--- a/koans/pom.xml
+++ b/koans/pom.xml
@@ -71,7 +71,7 @@
               <configuration>
                 <rules>
                   <requireMavenVersion>
-                    <version>3.0.5</version>
+                    <version>3.2.1</version>
                   </requireMavenVersion>
                   <requireJavaVersion>
                     <version>1.6</version>

--- a/lib/pom.xml
+++ b/lib/pom.xml
@@ -65,7 +65,7 @@
               <configuration>
                 <rules>
                   <requireMavenVersion>
-                    <version>3.0.5</version>
+                    <version>3.2.1</version>
                   </requireMavenVersion>
                   <requireJavaVersion>
                     <version>1.6</version>


### PR DESCRIPTION
Address issues #3 by upgrading the latest versions of Maven plugins and require version 3.2.1 of Maven.
